### PR TITLE
Add unit test for BCU cotizaciones web service request

### DIFF
--- a/TobacoFrontend/lib/Services/Cotizaciones_Service/cotizaciones_service.dart
+++ b/TobacoFrontend/lib/Services/Cotizaciones_Service/cotizaciones_service.dart
@@ -36,17 +36,25 @@ class BcuCotizacionesService {
     required DateTime desde,
     required DateTime hasta,
     required int grupo,
+    http.Client? client,
   }) async {
     final body =
         _envelope(monedas: monedas, desde: desde, hasta: hasta, grupo: grupo);
-    final resp = await http.post(
-      Uri.parse(_endpoint),
-      headers: {'Content-Type': 'text/xml; charset=utf-8'},
-      body: utf8.encode(body),
-    );
-    if (resp.statusCode != 200) {
-      throw Exception('HTTP ${resp.statusCode}: ${resp.body}');
+    final httpClient = client ?? http.Client();
+    try {
+      final resp = await httpClient.post(
+        Uri.parse(_endpoint),
+        headers: {'Content-Type': 'text/xml; charset=utf-8'},
+        body: utf8.encode(body),
+      );
+      if (resp.statusCode != 200) {
+        throw Exception('HTTP ${resp.statusCode}: ${resp.body}');
+      }
+      return resp.body;
+    } finally {
+      if (client == null) {
+        httpClient.close();
+      }
     }
-    return resp.body;
   }
 }

--- a/TobacoFrontend/test/services/bcu_cotizaciones_service_test.dart
+++ b/TobacoFrontend/test/services/bcu_cotizaciones_service_test.dart
@@ -1,0 +1,45 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:tobaco/Services/Cotizaciones_Service/cotizaciones_service.dart';
+
+void main() {
+  group('BcuCotizacionesService', () {
+    test('getCotizacionesRaw envia el request SOAP y retorna la respuesta cruda', () async {
+      late http.Request capturedRequest;
+      const fakeResponseBody = '<soapenv:Envelope>respuesta</soapenv:Envelope>';
+      final mockClient = MockClient((request) async {
+        capturedRequest = request;
+        return http.Response(fakeResponseBody, 200,
+            headers: {'content-type': 'text/xml; charset=utf-8'});
+      });
+
+      final response = await BcuCotizacionesService.getCotizacionesRaw(
+        monedas: const [2225],
+        desde: DateTime(2024, 1, 2),
+        hasta: DateTime(2024, 1, 5),
+        grupo: 0,
+        client: mockClient,
+      );
+
+      expect(response, fakeResponseBody);
+      expect(capturedRequest.method, equals('POST'));
+      expect(
+        capturedRequest.url.toString(),
+        equals('https://cotizaciones.bcu.gub.uy/wscotizaciones/servlet/awsbcucotizaciones'),
+      );
+      expect(
+        capturedRequest.headers['Content-Type'],
+        equals('text/xml; charset=utf-8'),
+      );
+
+      final soapBody = utf8.decode(capturedRequest.bodyBytes);
+      expect(soapBody, contains('<cot:item>2225</cot:item>'));
+      expect(soapBody, contains('<cot:FechaDesde>2024-01-02</cot:FechaDesde>'));
+      expect(soapBody, contains('<cot:FechaHasta>2024-01-05</cot:FechaHasta>'));
+      expect(soapBody, contains('<cot:Grupo>0</cot:Grupo>'));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- allow providing a custom HTTP client to the cotizaciones service so it can be mocked in tests
- add a unit test that verifies the SOAP request generated for the BCU web service

## Testing
- flutter test *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ca44991638832d8b38bd9a8f67ccb5